### PR TITLE
add support for headers validation

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,6 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   setupFiles: ['dotenv/config'],
-  testPathIgnorePatterns: ['/node_modules/', '/dist/', '/mocks/'],
+  testPathIgnorePatterns: ['/node_modules/', '/dist/', '__tests__/mocks'],
+  coveragePathIgnorePatterns: ['/node_modules/', '/dist/', '__tests__/mocks'],
 };

--- a/package.json
+++ b/package.json
@@ -7,6 +7,16 @@
   "repository": "https://github.com/bits-cr/middy-joi-validator",
   "author": "bits-cr",
   "license": "MIT",
+  "keywords": [
+    "middy",
+    "middleware",
+    "serverless",
+    "framework",
+    "AWS Lambda",
+    "validator",
+    "joi",
+    "schema"
+  ],
   "private": false,
   "scripts": {
     "build": "tsc",

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ const middleware = (opts: Options): middy.MiddlewareObj<APIGatewayProxyEvent, AP
         throw error;
       }
       if (preserveRawHeaders && !util.isDeepStrictEqual(value, request.event.headers)) {
-        request.event.rawHeaders = request.event.headers;
+        request.event.rawHeaders = { ...request.event.headers as any };
       }
       request.event.headers = value;
     }
@@ -44,7 +44,11 @@ const middleware = (opts: Options): middy.MiddlewareObj<APIGatewayProxyEvent, AP
         throw error;
       }
       if (preserveRawBody && !util.isDeepStrictEqual(value, request.event.body)) {
-        request.event.rawBody = request.event.body;
+        if (typeof request.event.body === 'string' || request.event.body instanceof (String)) {
+          request.event.rawBody = request.event.body.slice();
+        } else {
+          request.event.rawBody = { ...request.event.body as any };
+        }
       }
       request.event.body = value;
     }

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,7 +1,7 @@
 import Joi, { ValidationOptions } from 'joi';
 
 export interface Options {
-  inputSchema?: Joi.ObjectSchema | undefined;
+  inputSchema?: Joi.AnySchema | undefined;
   inputValidationOptions?: ValidationOptions | undefined;
   preserveRawBody?: boolean | undefined;
   inputErrorValidationMessage?: string | undefined;

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,15 +1,21 @@
-import Joi from 'joi';
+import Joi, { ValidationOptions } from 'joi';
 
 export interface Options {
   inputSchema?: Joi.ObjectSchema | undefined;
+  inputValidationOptions?: ValidationOptions | undefined;
   inputErrorValidationMessage?: string | undefined;
+  headersSchema?: Joi.ObjectSchema | undefined;
+  headersValidationOptions?: ValidationOptions | undefined;
+  headersErrorValidationMessage?: string | undefined;
   outputSchema?: Joi.ObjectSchema | undefined;
+  outputValidationOptions?: ValidationOptions | undefined;
   outputErrorValidationMessage?: string | undefined;
 }
 
 const defaultOptions: Options = {
-  inputSchema: undefined,
-  outputSchema: undefined
+  headersValidationOptions: {
+    allowUnknown: true,
+  }
 }
 
 export default Options;

--- a/src/options.ts
+++ b/src/options.ts
@@ -3,9 +3,11 @@ import Joi, { ValidationOptions } from 'joi';
 export interface Options {
   inputSchema?: Joi.ObjectSchema | undefined;
   inputValidationOptions?: ValidationOptions | undefined;
+  preserveRawBody?: boolean | undefined;
   inputErrorValidationMessage?: string | undefined;
   headersSchema?: Joi.ObjectSchema | undefined;
   headersValidationOptions?: ValidationOptions | undefined;
+  preserveRawHeaders?: boolean | undefined;
   headersErrorValidationMessage?: string | undefined;
   outputSchema?: Joi.ObjectSchema | undefined;
   outputValidationOptions?: ValidationOptions | undefined;
@@ -15,7 +17,9 @@ export interface Options {
 const defaultOptions: Options = {
   headersValidationOptions: {
     allowUnknown: true,
-  }
+  },
+  preserveRawBody: false,
+  preserveRawHeaders: false,
 }
 
 export default Options;

--- a/src/typings/aws-lambda.d.ts
+++ b/src/typings/aws-lambda.d.ts
@@ -1,6 +1,6 @@
 declare namespace AWSLambda {
   export interface APIGatewayProxyEvent {
-    body: string | null;
+    body: string | object | null;
     headers: APIGatewayProxyEventHeaders;
     multiValueHeaders: APIGatewayProxyEventMultiValueHeaders;
     httpMethod: string;
@@ -12,7 +12,7 @@ declare namespace AWSLambda {
     stageVariables: APIGatewayProxyEventStageVariables | null;
     requestContext: APIGatewayEventRequestContextWithAuthorizer<TAuthorizerContext>;
     resource: string;
-    rawBody: string | null;
-    rawHeaders: string | null;
+    rawBody: string | object | null;
+    rawHeaders: APIGatewayProxyEventHeaders | null;
   }
 }

--- a/src/typings/aws-lambda.d.ts
+++ b/src/typings/aws-lambda.d.ts
@@ -1,0 +1,18 @@
+declare namespace AWSLambda {
+  export interface APIGatewayProxyEvent {
+    body: string | null;
+    headers: APIGatewayProxyEventHeaders;
+    multiValueHeaders: APIGatewayProxyEventMultiValueHeaders;
+    httpMethod: string;
+    isBase64Encoded: boolean;
+    path: string;
+    pathParameters: APIGatewayProxyEventPathParameters | null;
+    queryStringParameters: APIGatewayProxyEventQueryStringParameters | null;
+    multiValueQueryStringParameters: APIGatewayProxyEventMultiValueQueryStringParameters | null;
+    stageVariables: APIGatewayProxyEventStageVariables | null;
+    requestContext: APIGatewayEventRequestContextWithAuthorizer<TAuthorizerContext>;
+    resource: string;
+    rawBody: string | null;
+    rawHeaders: string | null;
+  }
+}


### PR DESCRIPTION
1. Add support for headers validation.
2. Add options for preserve rawBody and rawHeaders.
3. Fix support for body type string and joi string validation.